### PR TITLE
[if_stage] Updated program_counter containing flush logic

### DIFF
--- a/Pipeline/ip/if_stage/dv/if_stage_tb.sv
+++ b/Pipeline/ip/if_stage/dv/if_stage_tb.sv
@@ -72,8 +72,10 @@ module if_stage_tb;
     // Flush
     $display("Flushing (NOP inject)");
     pc_imm = 32'h00000040;
+    pc_sel = 1;
     flush = 1;
     @(posedge clk);
+    pc_sel = 0;
     flush = 0;
 
     // Run a few more cycles

--- a/Pipeline/ip/if_stage/rtl/program_counter.sv
+++ b/Pipeline/ip/if_stage/rtl/program_counter.sv
@@ -28,9 +28,6 @@ always_ff @(posedge clk) begin
   if (!rst_n) begin
     pc_reg <= 32'd0;
   end
-  else if (flush) begin
-    pc_reg <= pc_imm;
-  end
   else if (stall) begin
     pc_reg <= pc_reg;
   end


### PR DESCRIPTION
Program counter previously flushed, redundant by pc_sel. Flush was removed only to contain stall given flush logic in IF/ID stage.